### PR TITLE
Allow all directories to be searched for step files.

### DIFF
--- a/cucumber_step_finder.py
+++ b/cucumber_step_finder.py
@@ -19,9 +19,9 @@ class CucumberBaseCommand(sublime_plugin.WindowCommand, object):
     self.steps = []
     folders = self.window.folders()
     for folder in folders:
-      for path in os.listdir(folder):
+      for path in os.listdir(folder) + ['.']:
         full_path = os.path.join(folder, path)
-        if path == self.features_path or self.features_path == '.':
+        if path == self.features_path:
           self.step_files = []
           for root, dirs, files in os.walk(full_path):
             for f_name in files:


### PR DESCRIPTION
I have a project with features scattered in multiple sub-projects so I'd like to be able to set the cucumber_features_path so that it searches the entire tree.  This modification allows for that if cucumber_features_path is set to `.`.
