### PR TITLE
Use ctrl+alt+y instead of ctrl+y on Linux and Windows

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,4 +1,4 @@
 [
-  { "keys": ["ctrl+y"], "command": "cucumber_step_finder" },
+  { "keys": ["ctrl+alt+y"], "command": "cucumber_step_finder" },
   { "keys": ["ctrl+shift+m"], "command": "match_step" }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,4 +1,4 @@
 [
-  { "keys": ["ctrl+y"], "command": "cucumber_step_finder" },
+  { "keys": ["ctrl+alt+y"], "command": "cucumber_step_finder" },
   { "keys": ["ctrl+shift+m"], "command": "match_step" }
 ]


### PR DESCRIPTION
ctrl+y is a common command for redo on Linux and Windows.
