### PR TITLE
Find steps beginning with regex symbols

### DIFF
--- a/CucumberStepFinder.sublime-settings
+++ b/CucumberStepFinder.sublime-settings
@@ -1,6 +1,7 @@
 {
-    "open_in_different_pane"  : true,
-    "cucumber_features_path"  :  "features",
-    "cucumber_step_pattern"   :  ".*_steps.*\\.rb",
-    "cucumber_code_keywords"  :  ["given", "when", "then", "and","but", "und", "dann", "wenn", "gegeben sei", "angenommen"]
+    "open_in_different_pane"   :  true,
+    "cucumber_features_path"   :  "features",
+    "cucumber_step_pattern"    :  ".*_steps.*\\.rb",
+    "cucumber_code_keywords"   :  ["given", "when", "then", "and","but", "und", "dann", "wenn", "gegeben sei", "angenommen"],
+    "regex_protected_keywords" :  ["*"]
 }

--- a/cucumber_step_finder.py
+++ b/cucumber_step_finder.py
@@ -102,7 +102,10 @@ class MatchStepCommand(CucumberBaseCommand):
 
   def cut_words(self, text):
      words = self.settings_get('cucumber_code_keywords')
+     regex_keywords = self.settings_get('regex_protected_keywords')
+
      upcased = [up.capitalize() for up in words]
+     [upcased.append("\\" + keyword) for keyword in regex_keywords]
      expression = "^{0}".format('|^'.join(upcased))
 
      pattern = re.compile(expression)


### PR DESCRIPTION
The trend in my company is to use Cucumber in a more bullet-point style, rather than a story style, and to start each bullet point with an asterisk. Adding an asterisk to the cucumber_code_keywords breaks the step finder, since it's also a regex symbol. The preferences won't allow you to escape characters, either. This change allows the user to customize which regex symbols, if any, they want to allow as a cucumber_code_keyword.
